### PR TITLE
Add monitoring of the events websocket to process-compose

### DIFF
--- a/dev-local/process-compose.yaml
+++ b/dev-local/process-compose.yaml
@@ -26,4 +26,29 @@ processes:
 
   script-reexecutor:
     command: "cabal run plutus-script-reexecutor -- run --node-socket devnet-env/socket/node1/sock --testnet-magic 42 --script-yaml local-config/scripts.yaml"
-    disabled: true
+    depends_on:
+      cardano-testnet: 
+        condition: process_healthy
+    readiness_probe:
+      http_get:
+        scheme: http
+        host: localhost
+        port: 8080
+        path: "/events/non-existant"
+      initial_delay_seconds: 1
+      period_seconds: 2
+      timeout_seconds: 1
+      success_threshold: 1
+      failure_threshold: 30
+
+  script-websocket-output:
+    command: "websocat --text ws://localhost:8080/events-ws/ threadedstdio: | jq -C --unbuffered"
+    depends_on: 
+      script-reexecutor:
+        condition: process_healthy
+
+  script-websocket-executions:
+    command: "websocat --text ws://localhost:8080/events-ws/?type=execution threadedstdio: | jq -C --unbuffered"
+    depends_on: 
+      script-reexecutor:
+        condition: process_healthy


### PR DESCRIPTION
Closes #91.

Adds two new processes, which monitor all events, and only execution events (to reduce noise).

It also automatically runs `plutus-script-reexecutor` once `cardano-node` is healthy to speed up dev time, and marks it ready once the `/events/non-existant` endpoint returns something.