### PR TITLE
Cancelled block table

### DIFF
--- a/dev-local/process-compose.yaml
+++ b/dev-local/process-compose.yaml
@@ -71,6 +71,12 @@ processes:
       script-reexecutor:
         condition: process_healthy
 
+  script-websocket-rollbacks:
+    command: "websocat --text ws://localhost:8090/events-ws/?type=rollback threadedstdio: | jq -C --unbuffered"
+    depends_on:
+      script-reexecutor:
+        condition: process_healthy
+
   script-logs-output:
     command: "tail -f events.log | jq -C --unbuffered"
     depends_on:

--- a/lib/PSR/Events.hs
+++ b/lib/PSR/Events.hs
@@ -7,6 +7,7 @@ import Data.Foldable (for_)
 import Data.Time (getCurrentTime)
 import PSR.Events.Interface
 import PSR.Storage.Interface (Storage (..))
+import PSR.Types (BlockStatus (..))
 
 withEvents :: Maybe Storage -> (Events -> IO ()) -> IO ()
 withEvents maybeStorage act = do
@@ -30,6 +31,7 @@ withEvents maybeStorage act = do
                         , slotNo
                         , createdAt
                         , payload = RollbackPayload blocksCancelled
+                        , blockStatus = BSCancelled
                         }
 
     let
@@ -44,6 +46,7 @@ withEvents maybeStorage act = do
                         , slotNo
                         , createdAt
                         , payload = SelectionPayload blockNo
+                        , blockStatus = BSUnknown
                         }
             for_ maybeStorage $ \s ->
                 s.addSelectionEvent blockHeader
@@ -63,6 +66,7 @@ withEvents maybeStorage act = do
                         , slotNo
                         , createdAt
                         , payload = ExecutionPayload blockNo payload
+                        , blockStatus = BSUnknown
                         }
             STM.atomically $ writeTChan eventsChannel event
             pure event

--- a/lib/PSR/Events/Interface.hs
+++ b/lib/PSR/Events/Interface.hs
@@ -14,6 +14,7 @@ import Data.Maybe (isNothing)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import GHC.Generics (Generic)
+import PSR.Types (BlockStatus)
 import PlutusLedgerApi.Common (Data, MajorProtocolVersion, PlutusLedgerLanguage)
 
 data EventType
@@ -34,6 +35,7 @@ data Event = Event
     , slotNo :: C.SlotNo
     , createdAt :: UTCTime
     , payload :: EventPayload
+    , blockStatus :: BlockStatus
     }
     deriving (Generic)
 

--- a/lib/PSR/HTTP/API.hs
+++ b/lib/PSR/HTTP/API.hs
@@ -16,6 +16,7 @@ import Data.Aeson (ToJSON (..), object, (.=))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import PSR.Events.Interface
+import PSR.Types (BlockStatus (..))
 import PlutusLedgerApi.Common (MajorProtocolVersion (..), PlutusLedgerLanguage (..))
 import Servant
 import Servant.API.WebSocket (WebSocketPending)
@@ -52,6 +53,13 @@ instance ToJSON ExecutionEventPayload where
             , "traceLogs" .= toJSON traceLogs
             , "evalError" .= toJSON evalError
             ]
+
+instance ToJSON BlockStatus where
+    toJSON =
+        toJSON @Text . \case
+            BSUnknown -> "unknown"
+            BSCancelled -> "cancelled"
+            BSCommitted -> "committed"
 
 instance ToJSON EventPayload
 instance ToJSON Event

--- a/lib/PSR/Storage/SQLite.hs
+++ b/lib/PSR/Storage/SQLite.hs
@@ -19,7 +19,6 @@ import PSR.Storage.SQLite.GetEvents qualified as GetEvents
 import PSR.Storage.SQLite.Instances ()
 import PSR.Storage.SQLite.Metrics (SqliteMetrics (..), initialiseMetrics)
 import PSR.Storage.SQLite.Utils
-import PSR.Types (BlockStatus (..))
 import PlutusLedgerApi.Common (MajorProtocolVersion (..))
 
 withSqliteStorage :: FilePath -> Int -> (Storage -> IO ()) -> IO ()
@@ -34,7 +33,7 @@ mkStorage confirmationDepth metrics pool = do
     withResource pool initSchema
     pure $ Storage{..}
   where
-    getEvents = GetEvents.getEvents metrics.getEvents_select pool
+    getEvents = GetEvents.getEvents metrics.getEvents_select pool confirmationDepth
 
     -- NOTE: The block may not always exist in our database. And it may not be
     -- possible to get the proper BlockHeader on a rollback event.
@@ -44,7 +43,6 @@ mkStorage confirmationDepth metrics pool = do
         let colsKnown =
                 [ col "slot_no" slotNo
                 , col "hash" hash
-                , col "status" BSUnknown
                 ]
             cols =
                 case mBlockNo of
@@ -60,24 +58,6 @@ mkStorage confirmationDepth metrics pool = do
     createBlockIfNotExists :: Connection -> BlockHeader -> IO ()
     createBlockIfNotExists conn (BlockHeader slotNo hash blockNo) =
         createBlockIfNotExistsUtil conn slotNo hash (Just blockNo)
-
-    commitBlock :: Connection -> BlockNo -> IO ()
-    commitBlock conn blockNoToCommit = do
-        let q = "UPDATE block SET status = :set_status WHERE block_no = :block_no AND status = :prev_status;"
-        executeNamed metrics.setBlockStatus_update conn q $
-            [ ":set_status" := BSCommitted
-            , ":prev_status" := BSUnknown
-            , ":block_no" := blockNoToCommit
-            ]
-
-    cancelBlocksAfterSlot :: Connection -> SlotNo -> IO [Hash BlockHeader]
-    cancelBlocksAfterSlot conn slotNo = do
-        let q = "UPDATE block SET status = :set_status WHERE slot_no > :slot_no RETURNING hash;"
-        fmap (fmap fromOnly) $
-            queryNamed metrics.setBlockStatus_update conn q $
-                [ ":set_status" := BSCancelled
-                , ":slot_no" := slotNo
-                ]
 
     getOrCreateCostModelParamsId :: Connection -> MajorProtocolVersion -> CostModel -> IO Integer
     getOrCreateCostModelParamsId conn (MajorProtocolVersion v) costModel = do
@@ -157,20 +137,28 @@ mkStorage confirmationDepth metrics pool = do
     addRollbackEvent slotNo hash =
         withResource pool $ \conn -> withTransaction conn $ do
             createPartialBlockIfNotExists conn slotNo hash
-            blocksCancelled <- cancelBlocksAfterSlot conn slotNo
-            let params =
-                    [ col "block_hash" hash
-                    , col "blocks_cancelled" blocksCancelled
+            [Only event_id] <-
+                sqlInsertReturning
+                    metrics.addRollbackEvent_insert
+                    conn
+                    "rollback_event"
+                    [col "block_hash" hash]
+                    ["event_id"]
+            let q' =
+                    "INSERT INTO rollback_block (event_id, block_hash) \
+                    \SELECT :event_id, hash FROM block WHERE slot_no > :slot_no \
+                    \RETURNING block_hash;"
+            fmap fromOnly
+                <$> queryNamed
+                    metrics.addRollbackBlock_insert
+                    conn
+                    q'
+                    [ ":event_id" := (event_id :: Integer)
+                    , ":slot_no" := slotNo
                     ]
-            sqlInsert
-                metrics.addRollbackEvent_insert
-                conn
-                "rollback_event"
-                params
-            pure blocksCancelled
 
     addSelectionEvent :: BlockHeader -> IO ()
-    addSelectionEvent blockHeader@(BlockHeader _ hash blockNo) =
+    addSelectionEvent blockHeader@(BlockHeader _ hash _) =
         withResource pool $ \conn -> withTransaction conn $ do
             void $ createBlockIfNotExists conn blockHeader
             let params = [col "block_hash" hash]
@@ -179,7 +167,6 @@ mkStorage confirmationDepth metrics pool = do
                 conn
                 "selection_event"
                 params
-            commitBlock conn (blockNo - fromIntegral confirmationDepth)
 
     getExecutionContexts :: [FilterBy] -> IO [(BlockHeader, ExecutionContextId, ExecutionContext)]
     getExecutionContexts filters =

--- a/lib/PSR/Storage/SQLite/GetEvents.hs
+++ b/lib/PSR/Storage/SQLite/GetEvents.hs
@@ -26,9 +26,10 @@ import PSR.Events.Interface (
 import PSR.Metrics qualified as Metrics
 import PSR.Storage.SQLite.Instances ()
 import PSR.Storage.SQLite.Utils
+import PSR.Types (BlockStatus)
 
-getEvents :: Metrics.Summary -> Pool Connection -> EventFilterParams -> IO [Event]
-getEvents getEvents_select pool EventFilterParams{..} =
+getEvents :: Metrics.Summary -> Pool Connection -> Int -> EventFilterParams -> IO [Event]
+getEvents getEvents_select pool confirmationDepth EventFilterParams{..} =
     withResource pool $ \conn -> withTransaction conn $ do
         let
             -- see `docs/specification.md` for default values
@@ -80,15 +81,25 @@ getEvents getEvents_select pool EventFilterParams{..} =
                 "SELECT b.slot_no, b.hash, b.block_no, \
                 \ CASE \
                 \   WHEN ec.block_hash IS NOT NULL THEN 'execution' \
-                \   WHEN c.block_hash IS NOT NULL THEN 'rollback' \
-                \   WHEN s.block_hash IS NOT NULL THEN 'selection' \
+                \   WHEN re.block_hash IS NOT NULL THEN 'rollback' \
+                \   WHEN s.block_hash  IS NOT NULL THEN 'selection' \
                 \ END, \
-                \ COALESCE(ee.created_at, c.created_at, s.created_at), \
+                \ COALESCE(ee.created_at, re.created_at, s.created_at), \
                 \ json(ee.trace_logs), \
-                \ c.blocks_cancelled, \
+                \ rb.block_hashes, \
                 \ ee.eval_error, \
                 \ ee.exec_budget_cpu, \
                 \ ee.exec_budget_mem, \
+                \ CASE \
+                \   WHEN rb.block_hashes IS NOT NULL \
+                \       THEN 'cancelled' \
+                \   WHEN \
+                \       b_max.max_block_no  IS NOT NULL AND \
+                \       b.block_no IS NOT NULL AND \
+                \       (b_max.max_block_no - :confirmation_depth) > b.block_no \
+                \       THEN 'committed' \
+                \   ELSE 'unknown' \
+                \ END,\
                 \ ec.transaction_hash, \
                 \ ec.target_script_hash, \
                 \ ec.target_script_name, \
@@ -103,20 +114,28 @@ getEvents getEvents_select pool EventFilterParams{..} =
                 \ ec.exec_budget_max_mem, \
                 \ cmp.params \
                 \ FROM block b \
-                \ LEFT JOIN execution_context ec ON ec.block_hash = b.hash \
-                \ LEFT JOIN execution_event ee ON ee.context_id = ec.context_id \
+                \ LEFT JOIN execution_context ec  ON ec.block_hash = b.hash \
+                \ LEFT JOIN execution_event   ee  ON ee.context_id = ec.context_id \
                 \ LEFT JOIN cost_model_params cmp ON cmp.params_id = ec.cost_model_params_id \
-                \ LEFT JOIN rollback_event c ON c.block_hash = b.hash \
-                \ LEFT JOIN selection_event s ON s.block_hash = b.hash "
+                \ LEFT JOIN selection_event   s   ON s.block_hash  = b.hash  \
+                \ LEFT JOIN rollback_event    re  ON re.block_hash = b.hash \
+                \ LEFT JOIN \
+                \   (SELECT event_id, string_agg(block_hash, ' ') AS block_hashes \
+                \    FROM rollback_block)     rb  ON re.event_id   = rb.event_id \
+                \ JOIN (SELECT max(block_no) as max_block_no from block) b_max"
                     <> whereQuery
-                    <> " ORDER BY COALESCE(ee.created_at, c.created_at, s.created_at) ASC \
+                    <> " ORDER BY COALESCE(ee.created_at, re.created_at, s.created_at) ASC \
                        \ LIMIT :limit \
                        \ OFFSET :offset"
 
-            parameters = whereParams <> [":limit" := limitParameter, ":offset" := offsetParameter]
-
-        rows <- queryNamed getEvents_select conn eventsQuery parameters
-        pure $ rowToEvent <$> rows
+            parameters =
+                whereParams
+                    <> [ ":limit" := limitParameter
+                       , ":offset" := offsetParameter
+                       , ":confirmation_depth" := confirmationDepth
+                       ]
+        fmap rowToEvent
+            <$> queryNamed getEvents_select conn eventsQuery parameters
   where
     rowToEvent ::
         ( ( SlotNo
@@ -129,6 +148,7 @@ getEvents getEvents_select pool EventFilterParams{..} =
           , Maybe EvalError
           , Maybe Integer
           , Maybe Integer
+          , BlockStatus
           )
             :. Maybe ExecutionContext
         ) ->
@@ -144,6 +164,7 @@ getEvents getEvents_select pool EventFilterParams{..} =
                 , evalError
                 , mExBudgetCpu
                 , mExBudgetMem
+                , blockStatus
                 )
                 :. mExecutionContext
             ) =
@@ -161,7 +182,7 @@ getEvents getEvents_select pool EventFilterParams{..} =
                         context <- mExecutionContext
                         blockNo <- mBlockNo
                         pure $ ExecutionPayload blockNo $ ExecutionEventPayload{..}
-                    Rollback -> pure $ RollbackPayload (maybe [] id blocksCancelled)
+                    Rollback -> pure $ RollbackPayload (fromMaybe [] blocksCancelled)
                     Selection -> SelectionPayload <$> mBlockNo
              in
                 Event{..}

--- a/lib/PSR/Storage/SQLite/Instances.hs
+++ b/lib/PSR/Storage/SQLite/Instances.hs
@@ -224,3 +224,21 @@ maybeField =
         fromField >=> \case
             Just v -> pure v
             _ -> pure Nothing
+
+instance
+    ( FromField a
+    , FromField b
+    , FromField c
+    , FromField d
+    , FromField e
+    , FromField f
+    , FromField g
+    , FromField h
+    , FromField i
+    , FromField j
+    , FromField k
+    ) =>
+    FromRow (a, b, c, d, e, f, g, h, i, j, k)
+    where
+    fromRow =
+        (,,,,,,,,,,) <$> field <*> field <*> field <*> field <*> field <*> field <*> field <*> field <*> field <*> field <*> field

--- a/lib/PSR/Storage/SQLite/Metrics.hs
+++ b/lib/PSR/Storage/SQLite/Metrics.hs
@@ -5,13 +5,13 @@ import PSR.Storage.SQLite.Instances ()
 
 data SqliteMetrics = SqliteMetrics
     { createBlockIfNotExists_insert :: Summary
-    , setBlockStatus_update :: Summary
     , getOrCreateCostModelParamsId_insert :: Summary
     , getOrCreateCostModelParamsId_select :: Summary
     , setOrCreateBlockId_insert :: Summary
     , setOrCreateBlockId_select :: Summary
     , addExecutionEvent_insert :: Summary
     , addRollbackEvent_insert :: Summary
+    , addRollbackBlock_insert :: Summary
     , addSelectionEvent_insert :: Summary
     , getEvents_select :: Summary
     , getExecutionContextByNameOrScriptHash_select :: Summary
@@ -23,10 +23,6 @@ initialiseMetrics = do
         regSummary
             "sqlite_createBlockIfNotExists_insert"
             "Execution time of createBlockIfNotExists insert query"
-    setBlockStatus_update <-
-        regSummary
-            "sqlite_setBlockStatus_update"
-            "Execution time of setBlockStatus update query"
     getOrCreateCostModelParamsId_select <-
         regSummary
             "sqlite_getOrCreateCostModelParamsId_select"
@@ -51,6 +47,10 @@ initialiseMetrics = do
         regSummary
             "sqlite_addRollbackEvent_insert"
             "Execution time of addRollbackEvent insert query"
+    addRollbackBlock_insert <-
+        regSummary
+            "sqlite_addRollbackBlock_insert"
+            "Execution time of addRollbackEvent block insert query"
     addSelectionEvent_insert <-
         regSummary
             "sqlite_addSelectionEvent_insert"

--- a/lib/PSR/Storage/SQLite/Utils.hs
+++ b/lib/PSR/Storage/SQLite/Utils.hs
@@ -64,7 +64,7 @@ initSchema conn = withTransaction conn $ do
 
 -- "col" is a convenience sugar over (:=)
 col :: (ToField v) => Text -> v -> NamedParam
-col k v = (T.cons ':' k) := v
+col k v = T.cons ':' k := v
 
 getParamKeys :: [NamedParam] -> [Text]
 getParamKeys params = [k | (k := _) <- params]

--- a/schema.sql
+++ b/schema.sql
@@ -1,73 +1,85 @@
-CREATE TABLE IF NOT EXISTS block (
-  hash BLOB PRIMARY KEY,
-  block_no UNSIGNED INTEGER,
-  slot_no UNSIGNED INTEGER NOT NULL,
-  status TEXT CHECK(status IN ('unknown', 'cancelled', 'committed'))
-) WITHOUT ROWID;
+CREATE TABLE
+  IF NOT EXISTS block (
+    hash BLOB PRIMARY KEY,
+    block_no UNSIGNED INTEGER,
+    slot_no UNSIGNED INTEGER NOT NULL
+  ) WITHOUT ROWID;
 
-CREATE INDEX IF NOT EXISTS idx_block_slot_no ON block(slot_no);
+CREATE INDEX IF NOT EXISTS idx_block_slot_no ON block (slot_no);
 
-CREATE TABLE IF NOT EXISTS execution_context (
-  context_id INTEGER PRIMARY KEY,
+CREATE TABLE
+  IF NOT EXISTS execution_context (
+    context_id INTEGER PRIMARY KEY,
+    block_hash BLOB NOT NULL REFERENCES block (hash),
+    cost_model_params_id INTEGER NOT NULL REFERENCES cost_model_params (params_id),
+    transaction_hash BLOB NOT NULL,
+    target_script_hash BLOB NOT NULL,
+    target_script_name TEXT,
+    shadow_script_hash BLOB NOT NULL,
+    shadow_script_name TEXT,
+    ledger_language SMALLINT NOT NULL,
+    major_protocol_version SMALLINT NOT NULL,
+    datum BLOB,
+    redeemer BLOB,
+    script_context BLOB NOT NULL,
+    exec_budget_max_cpu INTEGER NOT NULL,
+    exec_budget_max_mem INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 
-  block_hash BLOB NOT NULL REFERENCES block (hash),
-  cost_model_params_id INTEGER NOT NULL REFERENCES cost_model_params (params_id),
+CREATE INDEX IF NOT EXISTS idx_execution_context_block_hash ON execution_context (block_hash);
 
-  transaction_hash BLOB NOT NULL,
+CREATE INDEX IF NOT EXISTS idx_execution_context_created_at ON execution_context (created_at ASC);
 
-  target_script_hash BLOB NOT NULL,
-  target_script_name TEXT,
+CREATE TABLE
+  IF NOT EXISTS cost_model_params (
+    params_id INTEGER PRIMARY KEY,
+    params BLOB NOT NULL,
+    UNIQUE (params)
+  );
 
-  shadow_script_hash BLOB NOT NULL,
-  shadow_script_name TEXT,
+CREATE TABLE
+  IF NOT EXISTS execution_event (
+    event_id INTEGER PRIMARY KEY,
+    context_id INTEGER NOT NULL REFERENCES execution_context (context_id),
+    trace_logs TEXT NOT NULL,
+    eval_error TEXT,
+    exec_budget_cpu INTEGER NOT NULL,
+    exec_budget_mem INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 
-  ledger_language SMALLINT NOT NULL,
-  major_protocol_version SMALLINT NOT NULL,
-  datum BLOB,
-  redeemer BLOB,
-  script_context BLOB NOT NULL,
-  exec_budget_max_cpu INTEGER NOT NULL,
-  exec_budget_max_mem INTEGER NOT NULL,
+CREATE INDEX IF NOT EXISTS idx_execution_event_created_at ON execution_event (created_at ASC);
 
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+CREATE TABLE
+  IF NOT EXISTS rollback_event (
+    event_id INTEGER PRIMARY KEY,
+    block_hash BLOB NOT NULL REFERENCES block (hash),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 
-CREATE INDEX IF NOT EXISTS idx_execution_context_block_hash ON execution_context(block_hash);
-CREATE INDEX IF NOT EXISTS idx_execution_context_created_at ON execution_context(created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_rollback_event_block_hash ON rollback_event (block_hash);
 
-CREATE TABLE IF NOT EXISTS cost_model_params (
-  params_id INTEGER PRIMARY KEY,
-  params BLOB NOT NULL,
-  UNIQUE (params)
-);
+CREATE INDEX IF NOT EXISTS idx_rollback_event_created_at ON rollback_event (created_at ASC);
 
-CREATE TABLE IF NOT EXISTS execution_event (
-  event_id INTEGER PRIMARY KEY,
-  context_id INTEGER NOT NULL REFERENCES execution_context (context_id),
+CREATE TABLE
+  IF NOT EXISTS rollback_block (
+    event_id INTEGER NOT NULL REFERENCES rollback_event (event_id),
+    block_hash BLOB NOT NULL REFERENCES block (hash)
+  );
 
-  trace_logs TEXT NOT NULL,
-  eval_error TEXT,
-  exec_budget_cpu INTEGER NOT NULL,
-  exec_budget_mem INTEGER NOT NULL,
+CREATE INDEX IF NOT EXISTS idx_rollback_block_event ON rollback_block (event_id);
 
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-CREATE INDEX IF NOT EXISTS idx_execution_event_created_at ON execution_event(created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_rollback_block_hash ON rollback_block (block_hash);
 
-CREATE TABLE IF NOT EXISTS rollback_event (
-  event_id INTEGER PRIMARY KEY,
-  block_hash BLOB NOT NULL REFERENCES block (hash),
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  blocks_cancelled BLOB NOT NULL
-);
-CREATE INDEX IF NOT EXISTS idx_rollback_event_block_hash ON rollback_event(block_hash);
-CREATE INDEX IF NOT EXISTS idx_rollback_event_created_at ON rollback_event(created_at ASC);
+CREATE TABLE
+  IF NOT EXISTS selection_event (
+    event_id INTEGER PRIMARY KEY,
+    block_hash BLOB NOT NULL REFERENCES block (hash),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
 
-CREATE TABLE IF NOT EXISTS selection_event (
-  event_id INTEGER PRIMARY KEY,
-  block_hash BLOB NOT NULL REFERENCES block (hash),
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+CREATE INDEX IF NOT EXISTS idx_selection_event_block_hash ON selection_event (block_hash);
 
-CREATE INDEX IF NOT EXISTS idx_selection_event_block_hash ON selection_event(block_hash);
-CREATE INDEX IF NOT EXISTS idx_selection_event_created_at ON selection_event(created_at ASC)
+CREATE INDEX IF NOT EXISTS idx_selection_event_created_at ON selection_event (created_at ASC)
+-- Note: final statement should not have a semi-colon


### PR DESCRIPTION
This replaces the previous implementation of block status with a new rollback_block table and updated to the getEvents query to produce the status without mutation.

This hasn't been fully tested yet, it depends on #169.